### PR TITLE
Fix a bug in dpcmd.c

### DIFF
--- a/dpcmd.c
+++ b/dpcmd.c
@@ -1406,9 +1406,7 @@ void do_DisplayOrSave(void)
             for(i=0; i<Len; i++)
             {
                 if((i%16==0) && i != 0)
-                {
-                    printf("\n");
-                }
+                printf("\n");
                 printf("%02X  ",*(pBufferForLastReadData[g_uiDevNum-1]+i)); 
             }
             printf("\n\n");
@@ -1706,11 +1704,11 @@ bool Wait(const char* strOK,const char* strFail)
         gettimeofday (&tv , NULL);
         if(tv.tv_sec-basetv.tv_sec > timeOut)
         { 
+            timersub(&tv, &basetv, &diff);
             printf("%0.2f\t s elapsed\r",diff.tv_sec + 0.000001 * diff.tv_usec);
             printf("%s",msg_err_timeout_abortion); 
 	    g_is_operation_on_going=false;
             g_bStatus=false;
-            timersub(&tv, &basetv, &diff);
             return false;
         }
 

--- a/dpcmd.c
+++ b/dpcmd.c
@@ -1406,7 +1406,9 @@ void do_DisplayOrSave(void)
             for(i=0; i<Len; i++)
             {
                 if((i%16==0) && i != 0)
-                printf("\n");
+                {
+                    printf("\n");
+                }
                 printf("%02X  ",*(pBufferForLastReadData[g_uiDevNum-1]+i)); 
             }
             printf("\n\n");


### PR DESCRIPTION
Fix bug in `Wait` function where `diff` was used before calculation, leading to incorrect timeout reporting.

The `diff` variable in the `Wait` function was used in a `printf` statement before `timersub()` calculated its value. This resulted in uninitialized data being printed for elapsed time during a timeout. The fix reorders the operations to ensure `diff` is calculated before being used.